### PR TITLE
Add libraryfolders.vdf parsing for Steam handler

### DIFF
--- a/GameFinder.StoreHandlers.Steam/SteamHandler.cs
+++ b/GameFinder.StoreHandlers.Steam/SteamHandler.cs
@@ -156,7 +156,7 @@ namespace GameFinder.StoreHandlers.Steam
                 foreach (Match match in matches)
                 {
                     var groups = match.Groups;
-                    var path = groups["path"].Value;
+                    var path = Path.Combine(groups["path"].Value, "steamapps");
                     if (!Directory.Exists(path))
                     {
                         res.AddError($"Unable to find Universe at {path}");

--- a/GameFinder.StoreHandlers.Steam/SteamHandler.cs
+++ b/GameFinder.StoreHandlers.Steam/SteamHandler.cs
@@ -149,9 +149,10 @@ namespace GameFinder.StoreHandlers.Steam
             }
 
             lines = File.ReadAllLines(SteamLibraries, Encoding.UTF8);
+            var rx = new Regex(@"\s+""\d+\""\s+""(?<path>.+)""");
+
             foreach (var line in lines)
             {
-                var rx = new Regex(@"\s+""\d+\""\s+""(?<path>.+)""");
                 var matches = rx.Matches(line);
                 foreach (Match match in matches)
                 {

--- a/GameFinder.StoreHandlers.Steam/SteamHandler.cs
+++ b/GameFinder.StoreHandlers.Steam/SteamHandler.cs
@@ -1,9 +1,10 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using GameFinder.RegistryUtils;
 using JetBrains.Annotations;
 using Microsoft.Win32;
@@ -27,6 +28,7 @@ namespace GameFinder.StoreHandlers.Steam
         /// </summary>
         public readonly string? SteamPath;
         private string? SteamConfig { get; set; }
+        private string? SteamLibraries { get; set; }
 
         /// <summary>
         /// List of all found Steam Universes
@@ -73,9 +75,17 @@ namespace GameFinder.StoreHandlers.Steam
                 return;
             }
 
+            var steamLibraries = Path.Combine(steamPath, "steamapps", "libraryfolders.vdf");
+            if (!File.Exists(steamLibraries))
+            {
+                _initErrors.Add($"Unable to find libraryfolders.vdf at {steamLibraries}");
+                return;
+            }
+
             FoundSteam = true;
             SteamPath = steamPath;
             SteamConfig = steamConfig;
+            SteamLibraries = steamLibraries;
         }
 
         /// <summary>
@@ -96,16 +106,24 @@ namespace GameFinder.StoreHandlers.Steam
                 return;
             }
 
+            var steamLibraries = Path.Combine(steamPath, "steamapps", "libraryfolders.vdf");
+            if (!File.Exists(steamLibraries))
+            {
+                _initErrors.Add($"Unable to find libraryfolders.vdf at {steamLibraries}");
+                return;
+            }
+
             FoundSteam = true;
             SteamPath = steamPath;
             SteamConfig = steamConfig;
+            SteamLibraries = steamLibraries;
         }
 
         private Result<bool> FindAllUniverses()
         {
             if (!FoundSteam) return NotOk(_initErrors);
             if (SteamConfig == null) return NotOk(_initErrors);
-            if (SteamConfig == null) return NotOk(_initErrors);
+            if (SteamLibraries == null) return NotOk(_initErrors);
 
             var res = new Result<bool>();
             var lines = File.ReadAllLines(SteamConfig, Encoding.UTF8);
@@ -130,6 +148,28 @@ namespace GameFinder.StoreHandlers.Steam
                 SteamUniverses.Add(path);
             }
 
+            lines = File.ReadAllLines(SteamLibraries, Encoding.UTF8);
+            foreach (var line in lines)
+            {
+                var rx = new Regex(@"\s+""\d+\""\s+""(?<path>.+)""");
+                var matches = rx.Matches(line);
+                foreach (Match match in matches)
+                {
+                    var groups = match.Groups;
+                    var path = groups["path"].Value;
+                    if (!Directory.Exists(path))
+                    {
+                        res.AddError($"Unable to find Universe at {path}");
+                        continue;
+                    }
+
+                    if (!SteamUniverses.Contains(path))
+                    {
+                        SteamUniverses.Add(path);
+                    }
+                }
+            }
+
             if (SteamPath == null) return Ok(res);
             
             var defaultPath = Path.Combine(SteamPath, "steamapps");
@@ -144,7 +184,7 @@ namespace GameFinder.StoreHandlers.Steam
         {
             if (!FoundSteam) return NotOk(_initErrors);
             if (SteamConfig == null) return NotOk(_initErrors);
-            if (SteamConfig == null) return NotOk(_initErrors);
+            if (SteamLibraries == null) return NotOk(_initErrors);
             
             var universeRes = FindAllUniverses();
             if (!universeRes.Value)

--- a/GameFinder.Tests/Setup.cs
+++ b/GameFinder.Tests/Setup.cs
@@ -23,9 +23,12 @@ namespace GameFinder.Tests
             Directory.CreateDirectory(steamConfigDir);
             var steamConfig = Path.Combine(steamConfigDir, "config.vdf");
             File.WriteAllText(steamConfig, "Hello World!", Encoding.UTF8);
-
+            
             var steamappsDir = Path.Combine(steamDir, "steamapps");
             Directory.CreateDirectory(steamappsDir);
+
+            var steamLibraries = Path.Combine(steamappsDir, "libraryfolders.vdf");
+            File.WriteAllText(steamLibraries, "Hello World!", Encoding.UTF8);
 
             var manifestFile = GetFile("appmanifest_72850.acf");
             var manifestOutput = Path.Combine(steamappsDir, "appmanifest_72850.acf");

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ If you build some sort of game library manager like [Playnite](https://github.co
 
 Source: [SteamHandler.cs](GameFinder.StoreHandlers.Steam/SteamHandler.cs)
 
-Steam games can be easily found by searching through _"Steam Universes"_. An Universe is simply a folder where you install Steam games. You can find all Universes by parsing the `config.vdf` file in `Steam/config`. We can get the Steam folder by opening the registry key `HKEY_CURRENT_USER\Software\Valve\Steam` and getting the `SteamPath` value.
+Steam games can be easily found by searching through _"Steam Universes"_. An Universe is simply a folder where you install Steam games. You can find all Universes by parsing some configuration files in Steam folder. We can get the Steam folder by opening the registry key `HKEY_CURRENT_USER\Software\Valve\Steam` and getting the `SteamPath` value.
 
-The `config.vdf` file uses Valve's KeyValue format which is similar to JSON:
+The `config/config.vdf` file uses Valve's KeyValue format which is similar to JSON.  What we want to look for are these `BaseInstallFolder_X` values which point to a Universe folder.
 
 ```text
 "InstallConfigStore"
@@ -57,7 +57,21 @@ The `config.vdf` file uses Valve's KeyValue format which is similar to JSON:
 }
 ```
 
-What we want to look for are these `BaseInstallFolder_X` values which point to a Universe folder. The `steamapps` subdirectory contains the `appmanifest_*.acf` files we need. `.acf` files have the same KeyValue format as `.vdf` files so parsing very easy:
+The `steamapps/libraryfolders.vdf` uses the same type of formatting as above.  The lines with a numeric key point to a Universe folder.  These numbers should match up with the `BaseInstallFolder_X` values in `config/config.vdf`.
+
+```text
+"LibraryFolders"
+{
+	"TimeNextStatsReport"		"1623187700"
+	"ContentStatsID"		"-8832980547670729777"
+	"1"		"F:\\SteamLibrary"
+	"3"		"E:\\SteamLibrary"
+}
+```
+
+Both `config/config.vdf` and `steamapps/libraryfolders.vdf` are parsed for possible Universe locations.  Theoretically, Steam keeps these files synced but there have been some user reports of this not happening.
+
+The `steamapps` subdirectory contains the `appmanifest_*.acf` files we need. `.acf` files have the same KeyValue format as `.vdf` files so parsing very easy:
 
 ```text
 "AppState"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Source: [SteamHandler.cs](GameFinder.StoreHandlers.Steam/SteamHandler.cs)
 
 Steam games can be easily found by searching through _"Steam Universes"_. An Universe is simply a folder where you install Steam games. You can find all Universes by parsing some configuration files in the Steam folder. We can get the Steam folder by opening the registry key `HKEY_CURRENT_USER\Software\Valve\Steam` and getting the `SteamPath` value.
 
-The `config/config.vdf` file uses Valve's KeyValue format which is similar to JSON.  What we want to look for are these `BaseInstallFolder_X` values which point to a Universe folder.
+The `config/config.vdf` file uses Valve's KeyValue format which is similar to JSON. What we want to look for are these `BaseInstallFolder_X` values which point to a Universe folder.
 
 ```text
 "InstallConfigStore"
@@ -57,7 +57,7 @@ The `config/config.vdf` file uses Valve's KeyValue format which is similar to JS
 }
 ```
 
-The `steamapps/libraryfolders.vdf` uses the same type of formatting as above.  The lines with a numeric key point to a Universe folder.  These numbers should match up with the `BaseInstallFolder_X` values in `config/config.vdf`.
+The `steamapps/libraryfolders.vdf` uses the same type of formatting as above. The lines with a numeric key point to a Universe folder. These numbers should match up with the `BaseInstallFolder_X` values in `config/config.vdf`.
 
 ```text
 "LibraryFolders"
@@ -69,9 +69,9 @@ The `steamapps/libraryfolders.vdf` uses the same type of formatting as above.  T
 }
 ```
 
-Both `config/config.vdf` and `steamapps/libraryfolders.vdf` are parsed for possible Universe locations.  Theoretically, Steam keeps these files synced but there have been some user reports of this not happening.
+Both `config/config.vdf` and `steamapps/libraryfolders.vdf` are parsed for possible Universe locations. Steam should keep these files synced but there have been some user reports of this not happening.
 
-The `steamapps` subdirectory contains the `appmanifest_*.acf` files we need. `.acf` files have the same KeyValue format as `.vdf` files so parsing very easy:
+The `steamapps` subdirectory contains the `appmanifest_*.acf` files we need. `.acf` files have the same KeyValue format as `.vdf` files so parsing is very easy:
 
 ```text
 "AppState"

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you build some sort of game library manager like [Playnite](https://github.co
 
 Source: [SteamHandler.cs](GameFinder.StoreHandlers.Steam/SteamHandler.cs)
 
-Steam games can be easily found by searching through _"Steam Universes"_. An Universe is simply a folder where you install Steam games. You can find all Universes by parsing some configuration files in Steam folder. We can get the Steam folder by opening the registry key `HKEY_CURRENT_USER\Software\Valve\Steam` and getting the `SteamPath` value.
+Steam games can be easily found by searching through _"Steam Universes"_. An Universe is simply a folder where you install Steam games. You can find all Universes by parsing some configuration files in the Steam folder. We can get the Steam folder by opening the registry key `HKEY_CURRENT_USER\Software\Valve\Steam` and getting the `SteamPath` value.
 
 The `config/config.vdf` file uses Valve's KeyValue format which is similar to JSON.  What we want to look for are these `BaseInstallFolder_X` values which point to a Universe folder.
 


### PR DESCRIPTION
Steam should keep config/config.vdf and steamapps/libraryfolders.vdf
in sync but some users have experienced this not happening.  In
order to handle this, both files are now parsed for Steam Universe
locations.

WARNING WARNING WARNING:
~~1. This is currently untested as I haven't been able to figure out how to get Wabbajack to actually use the updated files yet.~~
2. This honestly might not be a good change to make at this point...?  I've seen a whole 2 users with this issue and I'm not entirely convinced they weren't doing something wrong.