### PR TITLE
Add a check in FindAllGames for if the universe exists

### DIFF
--- a/GameFinder.StoreHandlers.Steam/SteamHandler.cs
+++ b/GameFinder.StoreHandlers.Steam/SteamHandler.cs
@@ -188,6 +188,12 @@ namespace GameFinder.StoreHandlers.Steam
             
             foreach (var universe in SteamUniverses)
             {
+                if (!Directory.Exists(universe))
+                {
+                    res.AddError($"Universe does not exist at {universe}");
+                    continue;
+                }
+
                 var acfFiles = Directory.EnumerateFiles(universe, "*.acf", SearchOption.TopDirectoryOnly);
                 foreach (var acfFile in acfFiles)
                 {


### PR DESCRIPTION
I don't know why this is needed.  The attached log shows that this failed but FindAllUniverses has the same check...?!  

[Wabbajack.current (2).log](https://github.com/erri120/GameFinder/files/6650142/Wabbajack.current.2.log)
