### PR TITLE
Use runtime platform check in SteamHandler instead of targetting net6.0-windows 

### DIFF
--- a/GameFinder.RegistryUtils/GameFinder.RegistryUtils.csproj
+++ b/GameFinder.RegistryUtils/GameFinder.RegistryUtils.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <Title>GameFinder.RegistryUtils</Title>
-        <TargetFrameworks>netstandard2.1;net6.0-windows</TargetFrameworks>
+        <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     </PropertyGroup>
 

--- a/GameFinder.RegistryUtils/RegistryHelper.cs
+++ b/GameFinder.RegistryUtils/RegistryHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging;
 using Microsoft.Win32;
 
@@ -8,6 +8,10 @@ namespace GameFinder.RegistryUtils
     {
         private static object? GetObjectFromRegistry(RegistryKey key, string valueName, ILogger logger)
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return null;
+            }
             var value = key.GetValue(valueName);
             if (value == null)
                 logger.LogWarning("RegistryKey {Key} does not have a value {ValueName}", key, valueName);
@@ -35,6 +39,10 @@ namespace GameFinder.RegistryUtils
         
         internal static string? GetNullableStringValueFromRegistry(RegistryKey key, string valueName)
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return null;
+            }
             var value = key.GetValue(valueName);
             var sValue = value?.ToString();
             return sValue;

--- a/GameFinder.StoreHandlers.Steam/GameFinder.StoreHandlers.Steam.csproj
+++ b/GameFinder.StoreHandlers.Steam/GameFinder.StoreHandlers.Steam.csproj
@@ -2,12 +2,8 @@
 
     <PropertyGroup>
         <Title>GameFinder.StoreHandlers.Steam</Title>
-        <TargetFrameworks>netstandard2.1;net6.0;net6.0-windows</TargetFrameworks>
+        <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0-windows'">
-        <DefineConstants>Windows</DefineConstants>
     </PropertyGroup>
     
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
@@ -21,14 +17,12 @@
     <ItemGroup>
         <PackageReference Include="JetBrains.Annotations" Version="2022.1.0" PrivateAssets="all" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+        <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\GameFinder\GameFinder.csproj" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-windows'">
-        <ProjectReference Include="..\GameFinder.RegistryUtils\GameFinder.RegistryUtils.csproj" />
+      <ProjectReference Include="..\GameFinder.RegistryUtils\GameFinder.RegistryUtils.csproj" />
     </ItemGroup>
     
 </Project>

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ foreach (var steamGame in steamHandler.Games)
 
 ## Linux Support
 
-Gaming on Linux is not yet fully a thing and many stores don't have support for Linux. Steam is the only store with Linux support at the moment and you can get this by targeting `net5.0` instead of `net5.0-windows`. Using `net5.0-windows` is only required for accessing the Windows registry using `Microsoft.Win32.Registry` for finding Steam. If you do not need to find Steam and already know where it is located (eg in a CI environment) you can simply target `net5.0` and use the constructor where you can provide the path to the Steam installation. If you do not provide a path to Steam and target `net5.0`, the Steam Handler will go and look for Steam in the default Linux path at `~/steam`.
+Gaming on Linux is not yet fully a thing and many stores don't have support for Linux. Steam is the only store with Linux support at the moment. On Windows, the Steam Handler accesses the Windows registry using `Microsoft.Win32.Registry` for finding Steam. On other platforms, the Steam Handler will go and look for Steam in the default Linux path at `~/steam`.
 
 ## Supported Stores
 


### PR DESCRIPTION
Hi! First of all I'd like to thank you for creating this awesome library. It makes locating Steam games super easy.

What confused me was why it is not possible to locate Steam with `Microsoft.Win32.Registry` when targetting `net6.0`. In fact I use `Microsoft.Win32.Registry` to provide Steam install path to SteamHandler in my project (which targets `net6.0`), and it works without problems:
https://github.com/ParadoxGameConverters/commonItems.NET/blob/4ac18b0be81d7434f241799d0d48d8995bd9f895/commonItems/CommonFunctions.cs#L114
This PR should enable registry-based Steam location when targetting `net6.0`, which I think makes `net6.0-windows` redundant in the case of SteamHandler. Sorry if I'm ignorant of some technical limitations which prevent this from working.