### PR TITLE
Fix crash in EADesktopHandler with multiple video controllers

### DIFF
--- a/src/GameFinder.StoreHandlers.EADesktop/Crypto/Windows/WMIHelper.cs
+++ b/src/GameFinder.StoreHandlers.EADesktop/Crypto/Windows/WMIHelper.cs
@@ -34,8 +34,10 @@ internal static class WMIHelper
             var searcher = new ManagementObjectSearcher(selectQuery);
 
             using var results = searcher.Get();
+            if (results.Count <= 0)
+                throw new Exception("Property from query is not found.");
 
-            var arr = new ManagementBaseObject[1];
+            var arr = new ManagementBaseObject[results.Count];
             results.CopyTo(arr, 0);
 
             var baseObject = arr[0];


### PR DESCRIPTION
This fixes the crash mentioned in #114 when multiple video controllers exist.  Naively picking the first entry may not work for everyone, but it seems to be the right choice most of the time.