### PR TITLE
Fix crash in SteamHandler with missing library

### DIFF
--- a/src/GameFinder.StoreHandlers.Steam/Models/LibraryFolder.cs
+++ b/src/GameFinder.StoreHandlers.Steam/Models/LibraryFolder.cs
@@ -57,7 +57,7 @@ public sealed record LibraryFolder
     /// </summary>
     public Size GetFreeSpaceEstimate() => TotalDiskSize - GetTotalSizeOfInstalledApps();
 
-    private static readonly RelativePath SteamAppsDirectoryName = "steamapps".ToRelativePath();
+    public static readonly RelativePath SteamAppsDirectoryName = "steamapps".ToRelativePath();
 
     /// <summary>
     /// Returns an enumerable for every <c>appmanifest_*.acf</c> file path in the current library.

--- a/src/GameFinder.StoreHandlers.Steam/SteamHandler.cs
+++ b/src/GameFinder.StoreHandlers.Steam/SteamHandler.cs
@@ -81,7 +81,8 @@ public class SteamHandler : AHandler<SteamGame, AppId>
         foreach (var libraryFolder in libraryFolders)
         {
             var libraryFolderPath = libraryFolder.Path;
-            if (!_fileSystem.DirectoryExists(libraryFolderPath))
+            if (!_fileSystem.DirectoryExists(libraryFolderPath) ||
+                !_fileSystem.DirectoryExists(libraryFolderPath.Combine(Models.LibraryFolder.SteamAppsDirectoryName)))
             {
                 yield return new ErrorMessage($"Steam Library at {libraryFolderPath} doesn't exist!");
                 continue;


### PR DESCRIPTION
Fixes #133.  A fix might be done in NexusMods.Paths as well.