### PR TITLE
Fix crash in SteamHandler with unmatched quotation mark in library label

### DIFF
--- a/src/GameFinder.StoreHandlers.Steam/Services/Parsers/LibraryFoldersManifestParser.cs
+++ b/src/GameFinder.StoreHandlers.Steam/Services/Parsers/LibraryFoldersManifestParser.cs
@@ -35,7 +35,7 @@ public static class LibraryFoldersManifestParser
             using var stream = manifestPath.Read();
 
             var kv = KVSerializer.Create(KVSerializationFormat.KeyValues1Text);
-            var data = kv.Deserialize(stream, KVSerializerOptions.DefaultOptions);
+            var data = kv.Deserialize(stream, SteamHandler.KvSerializerOptions); // KVSerializerOptions.DefaultOptions);
 
             if (data is null)
             {

--- a/src/GameFinder.StoreHandlers.Steam/SteamHandler.cs
+++ b/src/GameFinder.StoreHandlers.Steam/SteamHandler.cs
@@ -22,7 +22,7 @@ public class SteamHandler : AHandler<SteamGame, AppId>
     private readonly IRegistry? _registry;
     private readonly IFileSystem _fileSystem;
 
-    private static readonly KVSerializerOptions KvSerializerOptions =
+    public static readonly KVSerializerOptions KvSerializerOptions =
         new()
         {
             HasEscapeSequences = true,


### PR DESCRIPTION
Workaround for #127 