### PR TITLE
More information for Epic Games

### DIFF
--- a/src/GameFinder.StoreHandlers.EGS/EGSGame.cs
+++ b/src/GameFinder.StoreHandlers.EGS/EGSGame.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using GameFinder.Common;
 using JetBrains.Annotations;
 using NexusMods.Paths;
@@ -11,4 +12,4 @@ namespace GameFinder.StoreHandlers.EGS;
 /// <param name="DisplayName"></param>
 /// <param name="InstallLocation"></param>
 [PublicAPI]
-public record EGSGame(EGSGameId CatalogItemId, string DisplayName, AbsolutePath InstallLocation) : IGame;
+public record EGSGame(EGSGameId CatalogItemId, string DisplayName, AbsolutePath InstallLocation, IReadOnlyList<string> ManifestHash) : IGame;

--- a/tests/GameFinder.StoreHandlers.EGS.Tests/ArrangeHelpers.cs
+++ b/tests/GameFinder.StoreHandlers.EGS.Tests/ArrangeHelpers.cs
@@ -38,13 +38,15 @@ public partial class EGSTests
                     var mockData = $@"{{
     ""CatalogItemId"": ""{catalogItemId}"",
     ""DisplayName"": ""{displayName}"",
-    ""InstallLocation"": ""{installLocation.GetFullPath().ToEscapedString()}""
+    ""InstallLocation"": ""{installLocation.GetFullPath().ToEscapedString()}"",
+    ""MainGameCatalogItemId"": ""{catalogItemId}"",
+    ""ManifestHash"": ""{catalogItemId}_manifest""
 }}";
 
                     fs.AddDirectory(installLocation);
                     fs.AddFile(manifestItem, mockData);
 
-                    return new EGSGame(EGSGameId.From(catalogItemId), displayName, installLocation);
+                    return new EGSGame(EGSGameId.From(catalogItemId), displayName, installLocation, new [] { catalogItemId + "_manifest" });
                 })
                 .OmitAutoProperties());
 

--- a/tests/TestUtils/AssertionHelpers.cs
+++ b/tests/TestUtils/AssertionHelpers.cs
@@ -48,7 +48,7 @@ public static class AssertionHelpers
         var results = handler.FindAllGames().ToArray();
         var games = results.ShouldOnlyBeGames();
 
-        games.Should().Equal(expectedGames);
+        games.Should().BeEquivalentTo(expectedGames);
     }
 
     public static void ShouldFindAllGamesById<TGame, TId>(
@@ -62,7 +62,7 @@ public static class AssertionHelpers
         errors.Should().BeEmpty();
 
         results.Should().ContainKeys(expectedGames.Select(keySelector));
-        results.Should().ContainValues(expectedGames);
+        results.Values.Should().BeEquivalentTo(expectedGames);
     }
 
     public static void ShouldFindAllInterfacesGames<TGame, TId>(
@@ -74,6 +74,6 @@ public static class AssertionHelpers
         var results = handler.FindAllInterfaceGames().ToArray();
         var games = results.ShouldOnlyBeGames();
 
-        games.Should().AllBeOfType<TGame>().Which.Should().Equal(expectedGames);
+        games.Should().AllBeOfType<TGame>().Which.Should().BeEquivalentTo(expectedGames);
     }
 }


### PR DESCRIPTION
In EGS, DLC are tracked in separate manifests, and link to the primary manifest via `MainGameCatalogItemId`. This PR does the following:

* Changes the parser to return manifests instead of games
* The handler now groups all parsed manifests by MainGameCatalogItemId (the main item itself has it's own id as the main game id, so we can simply group by this field)
* Introduces `ManifestId` which is the `BuildId` of sorts for the Epic Game store
* Returns a single record for each group, and returns the manifest ids. This brings the EGS code up to par with the recent changes to Steam's handlers

Had to also update some of the test code as the returned games now contain reference values, which don't work with `Equals`