### PR TITLE
Add support for GOG DLC detection (on Windows)

### DIFF
--- a/src/GameFinder.Launcher.Heroic/HeroicGOGGame.cs
+++ b/src/GameFinder.Launcher.Heroic/HeroicGOGGame.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using GameFinder.StoreHandlers.GOG;
@@ -17,7 +18,7 @@ public record HeroicGOGGame(
     AbsolutePath Path,
     ulong BuildId,
     WineData? WineData,
-    OSPlatform Platform) : GOGGame(Id, Name, Path, BuildId)
+    OSPlatform Platform) : GOGGame(Id, Name, Path, BuildId, null, Array.Empty<GOGGame>())
 {
     /// <summary>
     /// Gets the wine prefix, if any.

--- a/src/GameFinder.StoreHandlers.GOG/GOGGame.cs
+++ b/src/GameFinder.StoreHandlers.GOG/GOGGame.cs
@@ -8,4 +8,4 @@ namespace GameFinder.StoreHandlers.GOG;
 /// Represents a game installed with GOG Galaxy.
 /// </summary>
 [PublicAPI]
-public record GOGGame(GOGGameId Id, string Name, AbsolutePath Path, ulong BuildId) : IGame;
+public record GOGGame(GOGGameId Id, string Name, AbsolutePath Path, ulong BuildId, GOGGameId? DependsOn, GOGGame[] DLC) : IGame;

--- a/tests/GameFinder.StoreHandlers.GOG.Tests/ArrangeHelpers.cs
+++ b/tests/GameFinder.StoreHandlers.GOG.Tests/ArrangeHelpers.cs
@@ -30,7 +30,7 @@ public partial class GOGTests
                 gameKey.AddValue("path", path.GetFullPath());
                 gameKey.AddValue("buildId", $"{buildId}");
 
-                return new GOGGame(GOGGameId.From(id), name, path, buildId);
+                return new GOGGame(GOGGameId.From(id), name, path, buildId, null, Array.Empty<GOGGame>());
             })
             .OmitAutoProperties());
 


### PR DESCRIPTION
This adds support for DLC detection in GOG. Much like the Epic code, this grabs all the games, then groups them by error/game/dlc. DLC are added as sub-games on the base game, and then only the errors and base games are emitted by gamefinder. 